### PR TITLE
Github

### DIFF
--- a/features/step_definitions/linking_files.rb
+++ b/features/step_definitions/linking_files.rb
@@ -9,7 +9,7 @@ Given /^(.*) does not exist in (home|dotify)$/i do |file, location|
 end
 
 When /^they get linked by Dotify$/ do
-  @files_to_link.each { |file| Dotify::Unit.new(file).link }
+  @files_to_link.each { |file| Dotify::Dot.new(file).link }
 end
 
 Then /^they are all linked to the dotify path$/i do

--- a/lib/dotify.rb
+++ b/lib/dotify.rb
@@ -8,7 +8,7 @@ module Dotify
   autoload :Config,     'dotify/config'
   autoload :Collection, 'dotify/collection'
   autoload :Filter,     'dotify/filter'
-  autoload :Unit,       'dotify/unit'
+  autoload :Dot,       'dotify/dot'
   autoload :CLI,        'dotify/cli'
 
   def self.installed?

--- a/lib/dotify.rb
+++ b/lib/dotify.rb
@@ -8,7 +8,7 @@ module Dotify
   autoload :Config,     'dotify/config'
   autoload :Collection, 'dotify/collection'
   autoload :Filter,     'dotify/filter'
-  autoload :Dot,       'dotify/dot'
+  autoload :Dot,        'dotify/dot'
   autoload :CLI,        'dotify/cli'
 
   def self.installed?

--- a/lib/dotify/cli.rb
+++ b/lib/dotify/cli.rb
@@ -65,15 +65,17 @@ module Dotify
     end
 
     desc :github, "Pull the dotfiles from a specified github repo into your Dotify directory."
-    method_option :debug,   :aliases => '-d', :type => :boolean, :default => false, :desc => "Show error messages if there is a Git failure."
+    method_option :debug, :aliases => '-d', :type => :boolean, :default => false, :desc => "Show error messages if there is a Git failure."
     def github(repo)
       return say "Dotify has already been setup.", :blue if Dotify.installed?
       git_repo_name = "git@github.com:#{repo}.git"
       say "Pulling #{repo} from Github into #{Config.path}...", :blue
       Git.clone(git_repo_name, Config.path)
       say "Backing up dotfile and installing Dotify files...", :blue
-      Collection.new(:dotify).each do |file|
-        file.backup_and_link
+      Collection.new(:dotify).each { |file| file.backup_and_link }
+      if File.exists? File.join(Config.path, ".gitmodules")
+        say "Initializing and updating submodules in Dotify now...", :blue
+        system "cd #{Config.path} && git submodule init &> /dev/null && git submodule update &> /dev/null"
       end
       say "Successfully installed #{repo} from Dotify!", :blue
     rescue Git::GitExecuteError => e

--- a/lib/dotify/cli.rb
+++ b/lib/dotify/cli.rb
@@ -65,12 +65,20 @@ module Dotify
     end
 
     desc :github, "Pull the dotfiles from a specified github repo into your Dotify directory."
+    method_option :debug,   :aliases => '-d', :type => :boolean, :default => false, :desc => "Show error messages if there is a Git failure."
     def github(repo)
+      return say "Dotify has already been setup.", :blue if Dotify.installed?
       git_repo_name = "git@github.com:#{repo}.git"
       say "Pulling #{repo} from Github into #{Config.path}...", :blue
       Git.clone(git_repo_name, Config.path)
+      say "Backing up dotfile and installing Dotify files...", :blue
+      Collection.new(:dotify).each do |file|
+        file.backup_and_link
+      end
+      say "Successfully installed #{repo} from Dotify!", :blue
     rescue Git::GitExecuteError => e
       say "[ERROR]: There was an problem pulling from #{git_repo_name}.\nPlease make sure that the specified repo exists and you have access to it.", :red
+      say "Git Error: #{e.message}", :red if options[:debug]
     end
 
     desc :list, "List the installed dotfiles"

--- a/lib/dotify/cli.rb
+++ b/lib/dotify/cli.rb
@@ -64,6 +64,15 @@ module Dotify
       end
     end
 
+    desc :github, "Pull the dotfiles from a specified github repo into your Dotify directory."
+    def github(repo)
+      git_repo_name = "git@github.com:#{repo}.git"
+      say "Pulling #{repo} from Github into #{Config.path}...", :blue
+      Git.clone(git_repo_name, Config.path)
+    rescue Git::GitExecuteError => e
+      say "[ERROR]: There was an problem pulling from #{git_repo_name}.\nPlease make sure that the specified repo exists and you have access to it.", :red
+    end
+
     desc :list, "List the installed dotfiles"
     def list
       say "Dotify is managing #{Dotify.collection.linked.count} files:\n", :blue

--- a/lib/dotify/cli.rb
+++ b/lib/dotify/cli.rb
@@ -76,8 +76,8 @@ module Dotify
     desc :list, "List the installed dotfiles"
     def list
       say "Dotify is managing #{Dotify.collection.linked.count} files:\n", :blue
-      Dotify.collection.linked.each do |unit|
-        say "   * #{unit.filename}", :yellow
+      Dotify.collection.linked.each do |dot|
+        say "   * #{dot.filename}", :yellow
       end
       $stdout.write "\n"
     end
@@ -85,7 +85,7 @@ module Dotify
     desc 'edit [FILE]', "Edit a dotify file"
     method_option :save, :aliases => '-s', :default => false, :type => :boolean, :require => true, :desc => "Save Dotify files and push to Github"
     def edit(file)
-      file = Unit.new(file)
+      file = Dot.new(file)
       if file.linked?
         exec "#{Config.editor} #{file.dotify}"
         save if options[:save] == true
@@ -158,7 +158,7 @@ module Dotify
     def link(file = nil)
       return not_setup_warning unless Dotify.installed?
       # Link a single file
-      return file_action :link, Unit.new(file), options unless file.nil?
+      return file_action :link, Dot.new(file), options unless file.nil?
       # Relink the files
       return Dotify.collection.linked.each { |file| file_action(:link, file, options) } if options[:relink]
       # Link the files
@@ -176,7 +176,7 @@ module Dotify
     def unlink(file = nil)
       return not_setup_warning unless Dotify.installed?
       # Unlink a single file
-      return file_action :unlink, Unit.new(file), options unless file.nil?
+      return file_action :unlink, Dot.new(file), options unless file.nil?
       # Unlink the files
       Dotify.collection.linked.each { |file| file_action(:unlink, file, options) }
     end

--- a/lib/dotify/collection.rb
+++ b/lib/dotify/collection.rb
@@ -8,7 +8,12 @@ module Dotify
     # Pulls an array of Dots from the home
     # directory.
     def initialize(location = :dotfiles)
-      @dots ||= location == :dotfiles ? Filter.home : Filter.dotify
+      @dots ||= case location
+                when :dotfiles then Filter.home
+                when :dotify then Filter.dotify
+                else
+                  raise ArgumentError, "You must specify :dotfiles or :dotify when initializing Collection"
+                end
     end
 
     # Defined each method for Enumerable

--- a/lib/dotify/collection.rb
+++ b/lib/dotify/collection.rb
@@ -7,8 +7,8 @@ module Dotify
 
     # Pulls an array of Dots from the home
     # directory.
-    def initialize
-      @dots ||= Filter.home
+    def initialize(location = :dotfiles)
+      @dots ||= location == :dotfiles ? Filter.home : Filter.dotify
     end
 
     # Defined each method for Enumerable

--- a/lib/dotify/collection.rb
+++ b/lib/dotify/collection.rb
@@ -3,17 +3,17 @@ module Dotify
 
     include Enumerable
 
-    attr_accessor :units
+    attr_accessor :dots
 
-    # Pulls an array of Units from the home
+    # Pulls an array of Dots from the home
     # directory.
     def initialize
-      @units ||= Filter.home
+      @dots ||= Filter.home
     end
 
     # Defined each method for Enumerable
     def each(&block)
-      units.each(&block)
+      dots.each(&block)
     end
 
     # Linked files are those files which have a
@@ -30,11 +30,11 @@ module Dotify
     end
 
     def to_s
-      units.to_s
+      dots.to_s
     end
 
     def inspect
-      units.map(&:inspect)
+      dots.map(&:inspect)
     end
 
   end

--- a/lib/dotify/dot.rb
+++ b/lib/dotify/dot.rb
@@ -28,7 +28,7 @@ module Dotify
 
   end
 
-  class Unit
+  class Dot
 
     include Actions
 
@@ -64,7 +64,7 @@ module Dotify
     end
 
     def inspect
-      "#<Dotify::Unit filename: '#{@filename}' linked: #{linked?}>"
+      "#<Dotify::Dot filename: '#{@filename}' linked: #{linked?}>"
     end
 
     def linked_to_dotify?

--- a/lib/dotify/dot.rb
+++ b/lib/dotify/dot.rb
@@ -1,3 +1,4 @@
+require 'fileutils'
 require 'dotify/errors'
 
 module Dotify
@@ -15,6 +16,12 @@ module Dotify
       FileUtils.rm_rf(self.dotfile, :verbose => false)
       FileUtils.ln_sf(self.dotify, self.dotfile, :verbose => false)
       return true
+    end
+
+    def backup_and_link
+      FileUtils.rm_rf("#{self.dotfile}.bak", :verbose => false)
+      FileUtils.mv(self.dotfile, "#{self.dotfile}.bak", :verbose => false)
+      FileUtils.ln_sf(self.dotify, self.dotfile, :verbose => false)
     end
 
     # Unlink the file from Dotify and replace it into the home directory.

--- a/lib/dotify/errors.rb
+++ b/lib/dotify/errors.rb
@@ -1,4 +1,4 @@
 module Dotify
   class NonValidShell < StandardError; end
-  class UnitDoesNotExist < StandardError; end
+  class DotDoesNotExist < StandardError; end
 end

--- a/lib/dotify/filter.rb
+++ b/lib/dotify/filter.rb
@@ -5,30 +5,30 @@ module Dotify
     class << self
 
       def home
-        result = units(Config.home('.*'))
+        result = dots(Config.home('.*'))
         filter_ignore_files!(result, :dotfiles)
       end
 
       def dotify
-        result = units(Config.path('.*'))
+        result = dots(Config.path('.*'))
         filter_ignore_files!(result, :dotify)
       end
 
-      def units(glob)
-        filter_dot_directories! Dir[glob].map{ |file| Unit.new(file) }
+      def dots(glob)
+        filter_dot_directories! Dir[glob].map{ |file| Dot.new(file) }
       end
 
-      def filter_dot_directories!(units)
-        [*units].delete_if { |f| %w[. ..].include? f.filename }
+      def filter_dot_directories!(dots)
+        [*dots].delete_if { |f| %w[. ..].include? f.filename }
       end
 
-      def filter_ignore_files!(units, ignore)
+      def filter_ignore_files!(dots, ignore)
         ignoring = Config.ignore(ignore)
-        [*units].delete_if { |f| ignoring.include?(f.filename) }
+        [*dots].delete_if { |f| ignoring.include?(f.filename) }
       end
 
-      def filenames(units)
-        units.map(&:filename)
+      def filenames(dots)
+        dots.map(&:filename)
       end
 
     end

--- a/spec/dotify/cli_spec.rb
+++ b/spec/dotify/cli_spec.rb
@@ -7,25 +7,25 @@ module Dotify
     let!(:cli) { CLI.new }
     before do
       Dotify.stub(:installed?).and_return true
-      vimrc = Unit.new('.zshrc')
+      vimrc = Dot.new('.zshrc')
       vimrc.stub(:linked?).and_return(true)
-      bash_profile = Unit.new('.bash_profile')
+      bash_profile = Dot.new('.bash_profile')
       bash_profile.stub(:linked?).and_return(true)
-      gitconfig = Unit.new('.gitconfig')
+      gitconfig = Dot.new('.gitconfig')
       gitconfig.stub(:linked?).and_return(false)
-      zshrc = Unit.new('.zshrc')
+      zshrc = Dot.new('.zshrc')
       zshrc.stub(:linked?).and_return(false)
       Filter.stub(:home).and_return([vimrc, bash_profile, gitconfig, zshrc])
     end
 
     describe CLI, "#edit" do
-      let(:unit) { double('unit', :linked? => true, :dotify => '/tmp/dotify/.vimrc') }
+      let(:dot) { double('dot', :linked? => true, :dotify => '/tmp/dotify/.vimrc') }
       before do
-        Unit.stub(:new).and_return(unit)
+        Dot.stub(:new).and_return(dot)
         cli.stub(:exec)
       end
       it "should open the editor with the passed file" do
-        cli.should_receive(:exec).with([Config.editor, unit.dotify].join(" "))
+        cli.should_receive(:exec).with([Config.editor, dot.dotify].join(" "))
         cli.edit('.vimrc')
       end
       it "should  the editor with the passed file" do
@@ -34,8 +34,8 @@ module Dotify
         cli.edit '.vimrc'
       end
       it "should not edit the file if it has not been linked" do
-        unit.stub(:linked?).and_return false
-        cli.should_receive(:say).with("'#{unit}' has not been linked by Dotify. Please run `dotify link #{unit}` to edit this file.", :blue)
+        dot.stub(:linked?).and_return false
+        cli.should_receive(:say).with("'#{dot}' has not been linked by Dotify. Please run `dotify link #{dot}` to edit this file.", :blue)
         cli.edit('.vimrc')
       end
     end
@@ -59,7 +59,7 @@ module Dotify
         cli.link
       end
       it "attempt to link one single file" do
-        cli.should_receive(:file_action).with(:link, an_instance_of(Unit), {})
+        cli.should_receive(:file_action).with(:link, an_instance_of(Dot), {})
         cli.link('.vimrc')
       end
       it "should output a warning if Dotify is not installed" do
@@ -82,7 +82,7 @@ module Dotify
         cli.unlink
       end
       it "attempt to link one single file" do
-        cli.should_receive(:file_action).with(:unlink, an_instance_of(Unit), {})
+        cli.should_receive(:file_action).with(:unlink, an_instance_of(Dot), {})
         cli.unlink('.vimrc')
       end
       it "should output a warning if Dotify is not installed" do

--- a/spec/dotify/collection_spec.rb
+++ b/spec/dotify/collection_spec.rb
@@ -12,7 +12,7 @@ module Dotify
       ]
     }
     describe "methods" do
-      %w[linked unlinked].each do |name|
+      %w[each linked unlinked].each do |name|
         it "should respond to #{name}" do
           collection.should respond_to name
         end

--- a/spec/dotify/collection_spec.rb
+++ b/spec/dotify/collection_spec.rb
@@ -20,6 +20,9 @@ module Dotify
     end
 
     describe "pulling Filter#home or Filter#dotify files" do
+      it "should raise an error when not specifying :dotfiles or :dotify" do
+        expect { Collection.new(:fake) }.to raise_error ArgumentError
+      end
       it "should pull from Filter#home when default or dotfiles" do
         Filter.should_receive(:home).twice
         Collection.new(:dotfiles)

--- a/spec/dotify/collection_spec.rb
+++ b/spec/dotify/collection_spec.rb
@@ -6,9 +6,9 @@ module Dotify
     let(:collection) { Collection.new }
     let(:home_files) {
       [
-        @bashrc = double('unit1', :filename => '.bashrc', :linked? => false),
-        @gitconfig = double('unit2', :filename => '.gitconfig', :linked? => false),
-        @vimrc = double('unit3', :filename => '.vimrc', :linked? => true),
+        @bashrc = double('dot1', :filename => '.bashrc', :linked? => false),
+        @gitconfig = double('dot2', :filename => '.gitconfig', :linked? => false),
+        @vimrc = double('dot3', :filename => '.vimrc', :linked? => true),
       ]
     }
     describe "methods" do
@@ -22,46 +22,46 @@ module Dotify
     it "should pull the right files from Filter.home" do
       files = [stub, stub, stub]
       Filter.stub(:home).and_return files
-      collection.units.should == files
+      collection.dots.should == files
     end
 
     describe Collection, "#linked" do
       before do
-        collection.stub(:units).and_return home_files
+        collection.stub(:dots).and_return home_files
       end
       let(:linked) { collection.linked }
-      it "should return the right Units" do
+      it "should return the right Dots" do
         linked.should include @vimrc
         linked.should_not include @gitconfig
         linked.should_not include @bashrc
       end
-      it "should yield the correct Units" do
+      it "should yield the correct Dots" do
         expect { |b| collection.linked.each(&b) }.to yield_successive_args(*linked)
       end
     end
 
     describe Collection, "#unlinked" do
       before do
-        collection.stub(:units).and_return home_files
+        collection.stub(:dots).and_return home_files
       end
       let(:unlinked) { collection.unlinked }
-      it "should return the right Units" do
+      it "should return the right Dots" do
         unlinked.should include @gitconfig
         unlinked.should include @bashrc
         unlinked.should_not include @vimrc
       end
-      it "should yield the correct Units" do
+      it "should yield the correct Dots" do
         expect { |b| collection.unlinked.each(&b) }.to yield_successive_args(*unlinked)
       end
     end
 
-    it "should call #to_s on the units" do
-      collection.units.should_receive(:to_s)
+    it "should call #to_s on the dots" do
+      collection.dots.should_receive(:to_s)
       collection.to_s
     end
 
-    it "should call #inspect on the units" do
-      collection.units.each { |u| u.should_receive(:inspect) }
+    it "should call #inspect on the dots" do
+      collection.dots.each { |u| u.should_receive(:inspect) }
       collection.inspect
     end
 

--- a/spec/dotify/collection_spec.rb
+++ b/spec/dotify/collection_spec.rb
@@ -19,6 +19,17 @@ module Dotify
       end
     end
 
+    describe "pulling Filter#home or Filter#dotify files" do
+      it "should pull from Filter#home when default or dotfiles" do
+        Filter.should_receive(:home).twice
+        Collection.new(:dotfiles)
+        Collection.new
+      end
+      it "should pull from Filter#dotify when default or dotfiles" do
+        Filter.should_receive(:dotify).once
+        Collection.new(:dotify)
+      end
+    end
     it "should pull the right files from Filter.home" do
       files = [stub, stub, stub]
       Filter.stub(:home).and_return files

--- a/spec/dotify/config_spec.rb
+++ b/spec/dotify/config_spec.rb
@@ -10,7 +10,7 @@ module Dotify
         Config.stub(:file).and_return Config.home(".fake-dotrc")
         expect { Config.retrieve }.not_to raise_error TypeError
       end
-      context "unit tests" do
+      context "dot tests" do
         before do
           Config.instance_variable_set("@hash", nil)
           File.stub(:exists?).with(Config.file).and_return true

--- a/spec/dotify/config_spec.rb
+++ b/spec/dotify/config_spec.rb
@@ -19,6 +19,10 @@ module Dotify
           YAML.stub(:load_file).with(Config.file).and_return({})
           Config.retrieve.should == {}
         end
+        it "should catch the TypeError and return an empty hash" do
+          YAML.stub(:load_file).with(Config.file).and_raise(TypeError)
+          Config.retrieve.should == {}
+        end
         it "should return an the hash returned by YAML#load_file" do
           YAML.stub(:load_file).and_return({ :test => 'example' })
           Config.retrieve.should == { :test => 'example' }

--- a/spec/dotify/dot_spec.rb
+++ b/spec/dotify/dot_spec.rb
@@ -49,6 +49,14 @@ module Dotify
         subject.link
       end
     end
+    describe Actions, "#backup_and_link" do
+      it "should call the right FileUtils methods" do
+        FileUtils.should_receive(:rm_rf).with("#{subject.dotfile}.bak", :verbose => false)
+        FileUtils.should_receive(:mv).with(subject.dotfile, "#{subject.dotfile}.bak", :verbose => false)
+        FileUtils.should_receive(:ln_sf).with(subject.dotify, subject.dotfile, :verbose => false)
+        subject.backup_and_link
+      end
+    end
     describe Actions, "#unlink" do
       it "should not do anything if the file is not linked" do
         subject.stub(:linked?) { false }

--- a/spec/dotify/dot_spec.rb
+++ b/spec/dotify/dot_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
-require 'dotify/unit'
+require 'dotify/dot'
 
-class DummyUnit
+class DummyDot
   def dotfile
     '.dummy'
   end
@@ -17,7 +17,7 @@ end
 module Dotify
 
   describe Actions do
-    let!(:dummy) { DummyUnit.new }
+    let!(:dummy) { DummyDot.new }
     subject { dummy }
     before { dummy.extend(Actions) }
     it { should respond_to :link }
@@ -66,11 +66,11 @@ module Dotify
       end
     end
   end
-  describe Unit do
+  describe Dot do
 
     describe "populates the attributes correctly" do
-      let(:unit) { Unit.new(".vimrc") }
-      subject { unit }
+      let(:dot) { Dot.new(".vimrc") }
+      subject { dot }
       it { should respond_to :filename }
       it { should respond_to :dotify }
       it { should respond_to :dotfile }
@@ -79,85 +79,85 @@ module Dotify
       it { should respond_to :linked }
 
       it "should set the attributes properly" do
-        unit.filename.should == '.vimrc'
-        unit.dotify.should == '/tmp/home/.dotify/.vimrc'
-        unit.dotfile.should == '/tmp/home/.vimrc'
+        dot.filename.should == '.vimrc'
+        dot.dotify.should == '/tmp/home/.dotify/.vimrc'
+        dot.dotfile.should == '/tmp/home/.vimrc'
       end
       it "should puts the filename" do
-        unit.to_s.should == unit.filename
+        dot.to_s.should == dot.filename
       end
     end
 
     describe "existence in directories" do
-      let(:unit) { Unit.new(".bashrc") }
+      let(:dot) { Dot.new(".bashrc") }
       it "should check for the existence in the home directory" do
-        File.stub(:exists?).with(unit.dotfile).and_return true
-        unit.in_home_dir?.should == true
+        File.stub(:exists?).with(dot.dotfile).and_return true
+        dot.in_home_dir?.should == true
       end
       it "should return false if the file is not in the home directory" do
-        File.stub(:exists?).with(unit.dotfile).and_return false
-        unit.in_home_dir?.should_not == true
+        File.stub(:exists?).with(dot.dotfile).and_return false
+        dot.in_home_dir?.should_not == true
       end
       it "should check for the existence of the file in Dotify" do
-        File.stub(:exists?).with(unit.dotify).and_return true
-        unit.in_dotify?.should == true
+        File.stub(:exists?).with(dot.dotify).and_return true
+        dot.in_dotify?.should == true
       end
       it "should return false if the file is not in Dotify" do
-        File.stub(:exists?).with(unit.dotify).and_return false
-        unit.in_dotify?.should == false
+        File.stub(:exists?).with(dot.dotify).and_return false
+        dot.in_dotify?.should == false
       end
     end
 
-    describe Unit, "#linked_to_dotify?" do
-      let(:unit) { Unit.new(".bashrc") }
+    describe Dot, "#linked_to_dotify?" do
+      let(:dot) { Dot.new(".bashrc") }
       it "should return false when an error is raised" do
-        unit.stub(:symlink).and_return NoSymlink
-        unit.linked_to_dotify?.should be_false
+        dot.stub(:symlink).and_return NoSymlink
+        dot.linked_to_dotify?.should be_false
       end
       it "should return true if the dotfile is linked to the Dotify file" do
-        unit.stub(:symlink).and_return unit.dotify
-        unit.linked_to_dotify?.should be_true
+        dot.stub(:symlink).and_return dot.dotify
+        dot.linked_to_dotify?.should be_true
       end
       it "should return false if the dotfile is not linked to the Dotify file" do
-        File.stub(:readlink).with(unit.dotfile).and_return '/tmp/home/.another_file'
-        unit.linked_to_dotify?.should be_false
+        File.stub(:readlink).with(dot.dotfile).and_return '/tmp/home/.another_file'
+        dot.linked_to_dotify?.should be_false
       end
     end
 
-    describe Unit, "#linked?" do
-      let(:unit) { Unit.new(".bashrc") }
+    describe Dot, "#linked?" do
+      let(:dot) { Dot.new(".bashrc") }
       before do
-        unit.stub(:in_dotify?).and_return true # stub identical file check
+        dot.stub(:in_dotify?).and_return true # stub identical file check
       end
       it "should return true if all checks work" do
-        unit.stub(:linked_to_dotify?).and_return true # stub dotify file exist check
-        unit.linked?.should == true
+        dot.stub(:linked_to_dotify?).and_return true # stub dotify file exist check
+        dot.linked?.should == true
       end
       it "should return false if one or more checks fail" do
-        unit.stub(:linked_to_dotify?).and_return false # stub dotify file exist check
-        unit.linked?.should == false
+        dot.stub(:linked_to_dotify?).and_return false # stub dotify file exist check
+        dot.linked?.should == false
       end
     end
 
-    describe Unit, "#symlink" do
-      let!(:unit) { Unit.new(".symlinked") }
+    describe Dot, "#symlink" do
+      let!(:dot) { Dot.new(".symlinked") }
       it "should return the symlink for the file" do
-        File.should_receive(:readlink).with(unit.dotfile).once
-        unit.symlink
+        File.should_receive(:readlink).with(dot.dotfile).once
+        dot.symlink
       end
       it "should return NoSymlink if error or no symlink" do
-        File.stub(:readlink).with(unit.dotfile).and_raise(StandardError)
-        expect { unit.symlink }.not_to raise_error
-        unit.symlink.should == NoSymlink
+        File.stub(:readlink).with(dot.dotfile).and_raise(StandardError)
+        expect { dot.symlink }.not_to raise_error
+        dot.symlink.should == NoSymlink
       end
     end
 
-    describe "inspecting unit" do
+    describe "inspecting dot" do
       it "should display properly" do
-        Unit.new(".zshrc").inspect.should == "#<Dotify::Unit filename: '.zshrc' linked: false>"
-        bash = Unit.new(".bashrc")
+        Dot.new(".zshrc").inspect.should == "#<Dotify::Dot filename: '.zshrc' linked: false>"
+        bash = Dot.new(".bashrc")
         bash.stub(:linked?).and_return true
-        bash.inspect.should == "#<Dotify::Unit filename: '.bashrc' linked: true>"
+        bash.inspect.should == "#<Dotify::Dot filename: '.bashrc' linked: true>"
 
       end
     end

--- a/spec/dotify/filter_spec.rb
+++ b/spec/dotify/filter_spec.rb
@@ -4,17 +4,17 @@ module Dotify
   describe Filter do
 
     describe Filter, "#home" do
-      it "should call Filter#units with the correct path" do
-        Filter.should_receive(:units).with("/tmp/home/.*").once.and_return([])
+      it "should call Filter#dots with the correct path" do
+        Filter.should_receive(:dots).with("/tmp/home/.*").once.and_return([])
         Filter.home
       end
       it "should drop files that have been specified to be ignored" do
-        Filter.stub(:units) do
+        Filter.stub(:dots) do
           [
-            Unit.new('.zshrc'),
-            Unit.new('.bashrc'),
-            Unit.new('.vimrc'),
-            Unit.new('.gitconfig')
+            Dot.new('.zshrc'),
+            Dot.new('.bashrc'),
+            Dot.new('.vimrc'),
+            Dot.new('.gitconfig')
           ]
         end
         Config.stub(:ignore).with(:dotfiles).and_return %w[.zshrc .vimrc]
@@ -27,18 +27,18 @@ module Dotify
     end
 
     describe Filter, "#dotify" do
-      it "should call Filter#units with the correct path" do
-        Filter.should_receive(:units).with("/tmp/home/.dotify/.*").once.and_return([])
+      it "should call Filter#dots with the correct path" do
+        Filter.should_receive(:dots).with("/tmp/home/.dotify/.*").once.and_return([])
         Filter.dotify
       end
       it "should drop files that have been specified to be ignored" do
-        Filter.stub(:units) do
+        Filter.stub(:dots) do
           [
-            Unit.new(".gitconfig"),
-            Unit.new('.vimrc'),
-            Unit.new('.zshrc'),
-            Unit.new('.bashrc'),
-            Unit.new('.fakefile')
+            Dot.new(".gitconfig"),
+            Dot.new('.vimrc'),
+            Dot.new('.zshrc'),
+            Dot.new('.bashrc'),
+            Dot.new('.fakefile')
           ]
         end
         Config.stub(:ignore).with(:dotify).and_return %w[.gitconfig .bashrc]
@@ -51,17 +51,17 @@ module Dotify
       end
     end
 
-    describe Filter, "#units" do
+    describe Filter, "#dots" do
       let(:glob) { '/spec/test/.*' }
       it "should pull the glob of dotfiles from a directory" do
         Dir.should_receive(:[]).with(glob).and_return(%w[. .. /spec/test/.vimrc /spec/test/.bashrc /spec/test/.zshrc])
-        Filter.units(glob)
+        Filter.dots(glob)
       end
       describe "return values" do
         before do
           Dir.stub(:[]).with(glob).and_return(%w[. .. /spec/test/.vimrc /spec/test/.bashrc /spec/test/.zshrc])
         end
-        let(:files) { Filter.units(glob) }
+        let(:files) { Filter.dots(glob) }
         it "should return the right directories" do
           f = files.map(&:filename)
           f.should include '.vimrc'
@@ -78,9 +78,9 @@ module Dotify
 
     describe Filter, "#filenames" do
       let(:files) { [
-        Unit.new('.vimrc'), Unit.new('.bashrc'), Unit.new('.zshrc')
+        Dot.new('.vimrc'), Dot.new('.bashrc'), Dot.new('.zshrc')
       ] }
-      it "return only the filenames of the units" do
+      it "return only the filenames of the dots" do
         result = Filter.filenames(files)
         result.should include '.vimrc'
         result.should include '.bashrc'


### PR DESCRIPTION
- Renames `Unit` class to `Dot`. More consistent with the naming convention in the gem.
- Adds the `github [REPO]` task. **Note:** Not tested, but it works well on my own personal machine.
